### PR TITLE
New importing syntax

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var nativeImage = require('native-image')
+var nativeImage = require('electron').nativeImage
 var types = ['image/png', 'image/jpg', 'image/jpeg']
 
 module.exports = function canvasBuffer (canvas, type, quality) {


### PR DESCRIPTION
I updated my `electron-prebuilt` to `1.0.1` and `electron-canvas-to-buffer` cannot seem to find the `native-image` module. I fixed it by changing the `nativeImage` module importing syntax.
