### PR TITLE
 Updated deprecated toJpeg() and toPng() functions 

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,8 +13,8 @@ module.exports = function canvasBuffer (canvas, type, quality) {
     ? nativeImage.createFromDataURL(data) // electron v0.36+
     : nativeImage.createFromDataUrl(data) // electron v0.30
   if (/^image\/jpe?g$/.test(type)) {
-    return img.toJpeg(Math.floor(quality * 100))
+    return img.toJPEG(Math.floor(quality * 100))
   } else {
-    return img.toPng()
+    return img.toPNG()
   }
 }


### PR DESCRIPTION
Broken since Electron 2.0 
https://github.com/electron/electron/blob/master/docs/api/breaking-changes.md